### PR TITLE
Rockspec: fix build table and add more metadata (fixes #2)

### DIFF
--- a/misc/pegdebug-0.40-2.rockspec
+++ b/misc/pegdebug-0.40-2.rockspec
@@ -1,0 +1,27 @@
+package = "PegDebug"
+version = "0.40-2"
+
+source = {
+   url = "git://github.com/pkulchenko/PegDebug.git",
+   tag = "0.40",
+}
+
+description = {
+   summary = "PegDebug is a trace debugger for LPeg rules and captures.",
+   detailed = "PegDebug is a trace debugger for LPeg rules and captures.",
+   homepage = "http://github.com/pkulchenko/PegDebug",
+   maintainer = "Paul Kulchenko <paul@kulchenko.com>",
+   license = "MIT/X11",
+}
+
+dependencies = {
+   "lua >= 5.1",
+   "lpeg",
+}
+
+build = {
+   type = "builtin",
+   modules = {
+      ["pegdebug"] = "src/pegdebug.lua",
+   },
+}


### PR DESCRIPTION
The current rockspec does not work:

    $ luarocks install PegDebug
    Installing https://luarocks.org/pegdebug-0.40-1.rockspec
    ...
    Error: Build error: Missing build.modules table

Please release 0.40-2 on LuaRocks.